### PR TITLE
Remove copy-paste artifacts from CPUReactiveException

### DIFF
--- a/reactive-audit-lib/src/main/java/com/octo/reactive/audit/lib/CPUReactiveAuditException.java
+++ b/reactive-audit-lib/src/main/java/com/octo/reactive/audit/lib/CPUReactiveAuditException.java
@@ -17,7 +17,7 @@
 package com.octo.reactive.audit.lib;
 
 /**
- * Exception throw by the JVM agent if a file blocking API is used.
+ * Exception thrown by the JVM agent if a CPU bound blocking API is used.
  * This exception is thrown only if the throwExceptions parameter is true.
  *
  * @author Philippe PRADOS


### PR DESCRIPTION
JavaDoc of CPUReactiveAuditException mentions file API while exception is about CPU bound operations.
